### PR TITLE
Implement server-side start tournament view

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,62 @@
-from flask import Flask, send_from_directory
+from flask import Flask, render_template, request, redirect, url_for, session
+from tournament import draw_groups, schedule_round_robin
 
 app = Flask(__name__, static_folder='static', template_folder='templates')
+app.secret_key = 'replace-this-secret'
 
 @app.route('/')
 def index():
-    return send_from_directory(app.template_folder, 'index.html')
+    players = session.get('players', [])
+    return render_template('index.html', players=players)
+
+
+@app.route('/add', methods=['POST'])
+def add_player():
+    name = request.form.get('player_name', '').strip()
+    if name:
+        players = session.get('players', [])
+        players.append(name)
+        session['players'] = players
+    return redirect(url_for('index'))
+
+
+@app.route('/remove/<int:index>', methods=['POST'])
+def remove_player(index: int):
+    players = session.get('players', [])
+    if 0 <= index < len(players):
+        players.pop(index)
+        session['players'] = players
+    return redirect(url_for('index'))
+
+
+@app.route('/start', methods=['POST'])
+def start_tournament():
+    players = session.get('players', [])
+    if not players:
+        return redirect(url_for('index'))
+    group_a, group_b = draw_groups(players.copy())
+    schedule_a = [(m.p1, m.p2) for m in schedule_round_robin(group_a)]
+    schedule_b = [(m.p1, m.p2) for m in schedule_round_robin(group_b)]
+    standings_a = [{'name': p, 'points': 0, 'gd': 0} for p in group_a]
+    standings_b = [{'name': p, 'points': 0, 'gd': 0} for p in group_b]
+    session['tournament'] = {
+        'group_a': group_a,
+        'group_b': group_b,
+        'schedule_a': schedule_a,
+        'schedule_b': schedule_b,
+        'standings_a': standings_a,
+        'standings_b': standings_b,
+    }
+    return redirect(url_for('tournament_view'))
+
+
+@app.route('/tournament')
+def tournament_view():
+    t = session.get('tournament')
+    if not t:
+        return redirect(url_for('index'))
+    players = session.get('players', [])
+    return render_template('tournament.html', players=players, **t)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -34,6 +34,19 @@ button {
     margin-top: 1em;
 }
 
+#player-list {
+    list-style: none;
+    padding: 0;
+}
+
+#player-list li {
+    margin-bottom: 0.5em;
+}
+
+#player-list button {
+    margin-left: 0.5em;
+}
+
 @media (max-width: 600px) {
     body {
         padding: 0.5em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,10 +11,27 @@
 
     <section id="player-input-section">
         <h2>Enter Player Names</h2>
-        <form id="player-form">
-            <div id="player-inputs"></div>
+        <form action="{{ url_for('add_player') }}" method="post">
+            <input type="text" name="player_name" placeholder="Player name">
+            <button type="submit">Add</button>
+        </form>
+        {% if players %}
+        <ul id="player-list">
+            {% for p in players %}
+            <li>
+                {{ p }}
+                <form action="{{ url_for('remove_player', index=loop.index0) }}" method="post" style="display:inline">
+                    <button type="submit">Remove</button>
+                </form>
+            </li>
+            {% endfor %}
+        </ul>
+        <form action="{{ url_for('start_tournament') }}" method="post">
             <button type="submit">Start Tournament</button>
         </form>
+        {% else %}
+        <p>No players added yet.</p>
+        {% endif %}
     </section>
 
     <section id="group-stage" style="display:none">
@@ -29,6 +46,5 @@
         <div id="knockout-bracket"></div>
     </section>
 
-    <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tournament</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Tournament Started</h1>
+
+    <section>
+        <h2>Players</h2>
+        <ul>
+            {% for p in players %}
+            <li>{{ p }}</li>
+            {% endfor %}
+        </ul>
+    </section>
+
+    <section>
+        <h2>Group A</h2>
+        <p>{{ ', '.join(group_a) }}</p>
+        <h3>Matches</h3>
+        <ul>
+            {% for m in schedule_a %}
+            <li>{{ m[0] }} vs {{ m[1] }}</li>
+            {% endfor %}
+        </ul>
+        <h3>Standings</h3>
+        <table>
+            <tr><th>Player</th><th>Points</th><th>GD</th></tr>
+            {% for s in standings_a %}
+            <tr><td>{{ s.name }}</td><td>{{ s.points }}</td><td>{{ s.gd }}</td></tr>
+            {% endfor %}
+        </table>
+    </section>
+
+    <section>
+        <h2>Group B</h2>
+        <p>{{ ', '.join(group_b) }}</p>
+        <h3>Matches</h3>
+        <ul>
+            {% for m in schedule_b %}
+            <li>{{ m[0] }} vs {{ m[1] }}</li>
+            {% endfor %}
+        </ul>
+        <h3>Standings</h3>
+        <table>
+            <tr><th>Player</th><th>Points</th><th>GD</th></tr>
+            {% for s in standings_b %}
+            <tr><td>{{ s.name }}</td><td>{{ s.points }}</td><td>{{ s.gd }}</td></tr>
+            {% endfor %}
+        </table>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add start route and tournament page
- display players, roster, and standings on start
- enable Start Tournament button on index

## Testing
- `python -m py_compile tournament.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688010f92a1483249ebcae65367ad7cc