### PR TITLE
Add persistence with SQLite and tournament management

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,25 @@
 <body>
     <h1>Darts Tournament Manager</h1>
 
+    <section>
+        <h2>Previous Tournaments</h2>
+        {% if tournaments %}
+        <ul>
+            {% for t in tournaments %}
+            <li>
+                {{ t.name }} - {{ t.created_at }}
+                <a href="{{ url_for('tournament_view', t_id=t.id) }}">Open</a>
+                <form action="{{ url_for('delete_tournament', t_id=t.id) }}" method="post" style="display:inline">
+                    <button type="submit" class="styled-button">Delete</button>
+                </form>
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>No tournaments saved.</p>
+        {% endif %}
+    </section>
+
     <section id="player-input-section">
         <h2>Enter Player Names</h2>
         <form action="{{ url_for('add_player') }}" method="post">

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-    <h1>Tournament Started</h1>
+    <h1>Tournament {{ t_id }}</h1>
     <form id="reset-form" action="{{ url_for('reset') }}" method="post">
         <button id="reset-btn" type="button" class="styled-button">Go back to start</button>
     </form>
@@ -39,7 +39,7 @@
             <tr>
                 <td>{{ m.p1 }} vs {{ m.p2 }}</td>
                 <td>
-                    <form action="{{ url_for('record_score', group='A', index=loop.index0) }}" method="post" style="display:inline">
+                    <form action="{{ url_for('record_score', t_id=t_id, group='A', index=loop.index0) }}" method="post" style="display:inline">
                         <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
                         -
                         <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">


### PR DESCRIPTION
## Summary
- store tournaments in SQLite using simple schema
- list previous tournaments on the home page with open/delete options
- persist newly created tournaments and redirect to their pages
- keep standings ordered by points and goal difference
- support viewing and updating tournaments by id

## Testing
- `python -m py_compile app.py tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_68801e4efbb083249e289ca62f8eb400