### PR TITLE
Refine layout with SON Darts branding

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,10 +38,20 @@ def index():
     players = session.get('players', [])
     conn = get_db()
     rows = conn.execute(
-        "SELECT id, name, created_at FROM tournaments ORDER BY id DESC"
+        "SELECT id, name, created_at, data FROM tournaments ORDER BY id DESC"
     ).fetchall()
     conn.close()
-    tournaments = [dict(r) for r in rows]
+    tournaments = []
+    for r in rows:
+        data = json.loads(r["data"])
+        tournaments.append(
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "created_at": r["created_at"],
+                "players": data.get("players", []),
+            }
+        )
     return render_template(
         'index.html', players=players, tournaments=tournaments
     )

--- a/static/style.css
+++ b/static/style.css
@@ -1,77 +1,161 @@
+/* SON Darts Championship Styles */
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700;800&family=Roboto:wght@400;700&family=Roboto+Condensed:wght@700&display=swap');
+
+:root {
+  --son-navy: #001026;
+  --son-yellow: #FACA07;
+  --son-blue: #2B76E1;
+  --son-red: #F70001;
+  --son-green: #00874A;
+  --son-grey: #B3B2B4;
+  --son-radius: 8px;
+  --son-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 1em;
-    background: #f5f5f5;
+  font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+  margin: 0;
+  padding: 1em;
+  background: #fff;
+  color: var(--son-navy);
 }
 
-h1, h2 {
-    text-align: center;
+h1, h2, h3 {
+  font-family: 'Cinzel', 'Trajan Pro', Georgia, serif;
+  margin-top: 0;
+  text-align: center;
 }
 
-section {
-    margin-bottom: 2em;
-    background: #fff;
-    padding: 1em;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+h1 {
+  font-weight: 800;
+  font-size: 56px;
+  letter-spacing: 0.01em;
+}
+
+h2 {
+  font-weight: 700;
+  font-size: 40px;
+}
+
+h3 {
+  font-weight: 700;
+  font-size: 32px;
+}
+
+.index-layout, .tournament-layout {
+  display: flex;
+  gap: 4%;
+}
+
+#index-layout {
+  max-width: 72rem;
+}
+
+#new-tournament {
+  width: 28%;
+}
+
+#past-tournaments {
+  width: 68%;
+}
+
+.tournament-sidebar {
+  width: 28%;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+.matches {
+  width: 68%;
 }
 
 table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 1em;
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1em;
 }
 
 th, td {
-    padding: 0.5em;
-    border: 1px solid #ddd;
-    text-align: center;
+  padding: 0.5em;
+  border: 1px solid #ddd;
+  text-align: center;
 }
 
-button {
-    padding: 0.5em 1em;
-    margin-top: 1em;
+.card {
+  background: #fff;
+  padding: 1.5em;
+  border-radius: var(--son-radius);
+  box-shadow: var(--son-shadow);
+  border-top: 4px solid var(--son-yellow);
+  margin-bottom: 2em;
 }
 
 .styled-button {
-    padding: 0.25em 1em;
-    margin-top: 0;
-    background-color: #007bff; /* Voorbeeldkleur */
-    color: #fff; /* Tekstkleur */
-    border: none; /* Geen rand */
-    border-radius: 4px; /* Hoekafgeronde randen */
-    cursor: pointer; /* Cursor verandert bij hover */
-    font-size: 16px; /* Lettergrootte */
+  font-family: 'Roboto Condensed', 'Helvetica Neue', Arial, sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  background-color: var(--son-yellow);
+  color: var(--son-navy);
+  border: none;
+  padding: 0.5em 1em;
+  border-radius: var(--son-radius);
+  box-shadow: var(--son-shadow);
+  cursor: pointer;
+  transition: background-color 150ms ease-out, transform 150ms ease-out;
 }
+
 .styled-button:hover {
-    background-color: #0056b3; /* Donkerder bij hover */
+  background-color: #e2b208; /* darken 8% */
+  color: #fff;
+  transform: translateY(-1px) scale(1.03);
 }
 
 .styled-input {
-    margin: 1em 0; /* Boven- en ondermarge */
-    border: 1px solid #ced4da; /* Randkleur */
-    border-radius: 4px; /* Hoekafgeronde randen */
-    width: 250px; /* Breedte van het invoerveld */
-    font-size: 16px; /* Lettergrootte */
-    transition: border-color 0.3s; /* Voor een soepele overgang */
+  width: 100%;
+  padding: 0.5em;
+  font-size: 16px;
+  border: 1px solid var(--son-grey);
+  border-radius: var(--son-radius);
+  transition: box-shadow 150ms ease-out;
+}
+
+.styled-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--son-blue);
 }
 
 #player-list {
-    list-style: none;
-    padding: 0;
+  list-style: none;
+  padding: 0;
 }
 
 #player-list li {
-    margin-bottom: 0.5em;
+  margin-bottom: 0.5em;
 }
 
-#player-list button {
-    margin-left: 0.5em;
+.player-container {
+  margin-top: 1em;
 }
 
-@media (max-width: 600px) {
-    body {
-        padding: 0.5em;
-    }
+.caption {
+  font-size: 14px;
+  font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+  font-style: italic;
 }
+
+.actions {
+  margin-top: 0.5em;
+}
+
+@media (max-width: 768px) {
+  .index-layout, .tournament-layout {
+    flex-direction: column;
+  }
+  #new-tournament, #past-tournaments, .tournament-sidebar, .matches {
+    width: 100%;
+  }
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,51 +7,59 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-    <h1>Darts Tournament Manager</h1>
+    <h1>SON Darts Championship</h1>
 
-    <section>
-        <h2>Previous Tournaments</h2>
-        {% if tournaments %}
-        <ul>
-            {% for t in tournaments %}
-            <li>
-                {{ t.name }} - {{ t.created_at }}
-                <a href="{{ url_for('tournament_view', t_id=t.id) }}">Open</a>
-                <form action="{{ url_for('delete_tournament', t_id=t.id) }}" method="post" style="display:inline">
-                    <button type="submit" class="styled-button">Delete</button>
-                </form>
-            </li>
-            {% endfor %}
-        </ul>
-        {% else %}
-        <p>No tournaments saved.</p>
-        {% endif %}
-    </section>
+    <div class="index-layout">
+        <section id="new-tournament" class="card">
+            <h2>New Tournament</h2>
+            <form action="{{ url_for('add_player') }}" method="post" class="add-player-form">
+                <input type="text" class="styled-input" name="player_name" placeholder="Player name">
+                <button type="submit" class="styled-button">Add</button>
+            </form>
 
-    <section id="player-input-section">
-        <h2>Enter Player Names</h2>
-        <form action="{{ url_for('add_player') }}" method="post">
-            <input type="text" class="styled-input" name="player_name" placeholder="Player name">
-            <button type="submit" class="styled-button">Add</button>
-        </form>
-        {% if players %}
-        <ul id="player-list">
-            {% for p in players %}
-            <li>
-                {{ p }}
-                <form action="{{ url_for('remove_player', index=loop.index0) }}" method="post" style="display:inline">
-                    <button type="submit" class="styled-button">Remove</button>
+            <div class="player-container">
+                {% if players %}
+                <ul id="player-list">
+                    {% for p in players %}
+                    <li>
+                        {{ p }}
+                        <form action="{{ url_for('remove_player', index=loop.index0) }}" method="post" style="display:inline">
+                            <button type="submit" class="styled-button">Remove</button>
+                        </form>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <form action="{{ url_for('start_tournament') }}" method="post">
+                    <button type="submit" class="styled-button">Start Tournament</button>
                 </form>
-            </li>
-            {% endfor %}
-        </ul>
-        <form action="{{ url_for('start_tournament') }}" method="post">
-            <button type="submit">Start Tournament</button>
-        </form>
-        {% else %}
-        <p>No players added yet.</p>
-        {% endif %}
-    </section>
+                {% else %}
+                <p>No players added yet.</p>
+                {% endif %}
+            </div>
+        </section>
+
+        <section id="past-tournaments" class="card">
+            <h2>Past Tournaments</h2>
+            {% if tournaments %}
+            <ul class="tournament-list">
+                {% for t in tournaments %}
+                <li>
+                    <strong>{{ t.name }}</strong> - {{ t.created_at }}<br>
+                    <span class="caption">Players in tournament: {{ t.players|length }}</span>
+                    <div class="actions">
+                        <a href="{{ url_for('tournament_view', t_id=t.id) }}" class="styled-button">Open</a>
+                        <form action="{{ url_for('delete_tournament', t_id=t.id) }}" method="post" style="display:inline">
+                            <button type="submit" class="styled-button">Delete</button>
+                        </form>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p>No tournaments saved.</p>
+            {% endif %}
+        </section>
+    </div>
 
     <section id="group-stage" style="display:none">
         <h2>Group Stage</h2>

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -20,43 +20,50 @@
         </div>
     </div>
 
-    <section>
-        <h2>Players</h2>
-        <ul>
-            {% for p in players %}
-            <li>{{ p }}</li>
-            {% endfor %}
-        </ul>
-    </section>
+    <div class="tournament-layout">
+        <div class="tournament-sidebar">
+            <section class="players card">
+                <h2>Players</h2>
+                <ul>
+                    {% for p in players %}
+                    <li>{{ p }}</li>
+                    {% endfor %}
+                </ul>
+            </section>
 
-    <section>
-        <h2>Group A</h2>
-        <p>{{ ', '.join(group_a) }}</p>
-        <h3>Matches</h3>
-        <table>
-            <tr><th>Match</th><th>Score</th></tr>
-            {% for m in schedule_a %}
-            <tr>
-                <td>{{ m.p1 }} vs {{ m.p2 }}</td>
-                <td>
-                    <form action="{{ url_for('record_score', t_id=t_id, group='A', index=loop.index0) }}" method="post" style="display:inline">
-                        <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
-                        -
-                        <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
-                        <button type="submit" class="styled-button">Save</button>
-                    </form>
-                </td>
-            </tr>
-            {% endfor %}
-        </table>
-        <h3>Standings</h3>
-        <table>
-            <tr><th>Player</th><th>Points</th><th>GD</th></tr>
-            {% for s in standings_a %}
-            <tr><td>{{ s.name }}</td><td>{{ s.points }}</td><td>{{ s.gd }}</td></tr>
-            {% endfor %}
-        </table>
-    </section>
+            <section class="standings card">
+                <h2>Standings</h2>
+                <table>
+                    <tr><th>Player</th><th>Points</th><th>GD</th></tr>
+                    {% for s in standings_a %}
+                    <tr><td>{{ s.name }}</td><td>{{ s.points }}</td><td>{{ s.gd }}</td></tr>
+                    {% endfor %}
+                </table>
+            </section>
+        </div>
+
+        <div class="matches card">
+            <h2>Group A</h2>
+            <p>{{ ', '.join(group_a) }}</p>
+            <h3>Matches</h3>
+            <table>
+                <tr><th>Match</th><th>Score</th></tr>
+                {% for m in schedule_a %}
+                <tr>
+                    <td>{{ m.p1 }} vs {{ m.p2 }}</td>
+                    <td>
+                        <form action="{{ url_for('record_score', t_id=t_id, group='A', index=loop.index0) }}" method="post" style="display:inline">
+                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
+                            -
+                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
+                            <button type="submit" class="styled-button">Save</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+    </div>
 
     <script>
         const resetBtn = document.getElementById('reset-btn');


### PR DESCRIPTION
## Summary
- redesign index and tournament pages using flex layouts
- show players per saved tournament on the index
- apply SON Darts Championship branding styles

## Testing
- `python -m py_compile app.py tournament.py`
- `python app.py` *(fails without Flask; installed Flask then server started)*

------
https://chatgpt.com/codex/tasks/task_e_6880a54b4ba08324b14a1b70ca0f3336