### PR TITLE
Show group stage matches by round

### DIFF
--- a/app.py
+++ b/app.py
@@ -87,6 +87,7 @@ def start_tournament():
         'p2': m.p2,
         'score1': None,
         'score2': None,
+        'round': m.round,
     } for m in schedule_round_robin(group_a)]
     standings_a = [{'name': p, 'points': 0, 'gd': 0} for p in group_a]
 
@@ -211,11 +212,17 @@ def tournament_view(t_id: int):
     data = json.loads(row['data'])
     standings_a = data.get('standings_a', [])
     standings_a = sorted(standings_a, key=lambda x: (-x['points'], -x['gd']))
+
+    schedule_a = data.get('schedule_a', [])
+    rounds = {}
+    for m in schedule_a:
+        rounds.setdefault(m.get('round', 1), []).append(m)
+    schedule_by_round = [rounds[r] for r in sorted(rounds)]
     return render_template(
         'tournament.html',
         players=data.get('players', []),
         group_a=data.get('group_a', []),
-        schedule_a=data.get('schedule_a', []),
+        schedule_rounds=schedule_by_round,
         standings_a=standings_a,
         t_id=t_id,
     )

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -50,14 +50,16 @@
 
         <div class="matches card">
             <h2>Group Stage</h2>
-            <h3 style="text-align: left;">Matches</h3>
+            {% set ns = namespace(idx=0) %}
+            {% for round in schedule_rounds %}
+            <h3 style="text-align: left;">Round {{ loop.index }}</h3>
             <table>
                 <tr><th>Match</th><th>Score</th></tr>
-                {% for m in schedule_a %}
+                {% for m in round %}
                 <tr>
                     <td>{{ m.p1 }} vs {{ m.p2 }}</td>
                     <td>
-                        <form action="{{ url_for('record_score', t_id=t_id, group='A', index=loop.index0) }}" method="post" style="display:inline">
+                        <form action="{{ url_for('record_score', t_id=t_id, group='A', index=ns.idx) }}" method="post" style="display:inline">
                             <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
                             -
                             <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
@@ -65,8 +67,10 @@
                         </form>
                     </td>
                 </tr>
+                {% set ns.idx = ns.idx + 1 %}
                 {% endfor %}
             </table>
+            {% endfor %}
         </div>
     </div>
 

--- a/tournament.py
+++ b/tournament.py
@@ -8,6 +8,7 @@ class Match:
     p2: str
     score1: Optional[int] = None
     score2: Optional[int] = None
+    round: int = 0
 
 @dataclass
 class Standing:
@@ -21,11 +22,21 @@ def draw_group(players: List[str]) -> List[str]:
     return players
 
 def schedule_round_robin(players: List[str]) -> List[Match]:
-    matches = []
-    for i in range(len(players)):
-        for j in range(i + 1, len(players)):
-            matches.append(Match(players[i], players[j]))
-    return matches
+    """Create a round-robin schedule returning matches with round numbers."""
+    players = players.copy()
+    if len(players) % 2 == 1:
+        players.append(None)
+    n = len(players)
+    rounds: List[Match] = []
+    for r in range(n - 1):
+        for i in range(n // 2):
+            p1 = players[i]
+            p2 = players[n - 1 - i]
+            if p1 is not None and p2 is not None:
+                rounds.append(Match(p1, p2, round=r + 1))
+        # rotate list except the first element
+        players = [players[0]] + players[-1:] + players[1:-1]
+    return rounds
 
 def input_score(prompt: str) -> int:
     while True:


### PR DESCRIPTION
## Summary
- generate round-based schedule in `schedule_round_robin`
- store round numbers when starting tournament
- group matches by round in the tournament view
- display rounds in the tournament page

## Testing
- `python -m py_compile app.py tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b5173ee883249deb2cd17f1c390f