### PR TITLE
Enlarge header logo

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -43,10 +43,13 @@ body {
   background: var(--son-navy);
   color: var(--son-white);
   padding: 0.5em 1em;
+  height: 120px;
 }
 
 .site-header img {
-  height: 60px;
+  height: 100%;
+  align-self: stretch;
+  margin: -0.5em -1em;
 }
 
 h1, h2, h3 {


### PR DESCRIPTION
## Summary
- enlarge the header image by stretching it to the full header height
- offset the image margins so padding doesn't constrain it

## Testing
- `python -m py_compile app.py tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b6e1ed5c8324b107cfb4d7c0ec46