### PR TITLE
Add admin login and guest restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ python app.py
 
 Then navigate to `http://localhost:5000/` to use the tournament manager.
 
+The main page allows an administrator to log in. Use the default credentials:
+
+```
+username: admin
+password: password
+```
+
+Only an authenticated admin can create or modify tournaments.
+
 ## CLI Usage
 
 A command-line implementation is also available. Run:

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,9 +15,22 @@
         <img src="{{ url_for('static', filename='Dutch_darts_v2.png') }}" alt="Logo">
     </header>
 
+    {% if not session.admin_logged_in %}
+    <form action="{{ url_for('login') }}" method="post" class="card" style="margin-bottom:1em;">
+        <input type="text" name="username" placeholder="Username" class="styled-input" required>
+        <input type="password" name="password" placeholder="Password" class="styled-input" required style="margin-top:0.5em;">
+        <button type="submit" class="styled-button secondary-button" style="margin-top:0.5em;">Login</button>
+    </form>
+    {% else %}
+    <form action="{{ url_for('logout') }}" method="post" class="card" style="margin-bottom:1em;">
+        <button type="submit" class="styled-button secondary-button">Logout</button>
+    </form>
+    {% endif %}
+
     <div class="index-layout">
         <section id="new-tournament" class="card">
             <h2>New Tournament</h2>
+            {% if session.admin_logged_in %}
             <form action="{{ url_for('add_player') }}" method="post" class="add-player-form">
                 <input type="text" class="styled-input" name="player_name" placeholder="Player name">
                 <button type="submit" class="styled-button primary-button" style="margin-top: 0.25em;">Add</button>
@@ -42,6 +55,9 @@
                 <p>No players added yet.</p>
                 {% endif %}
             </div>
+            {% else %}
+            <p>Login as admin to create tournaments.</p>
+            {% endif %}
         </section>
 
         <section id="past-tournaments" class="card">
@@ -54,9 +70,11 @@
                     <span class="caption">Players in tournament: {{ t.players|length }}</span>
                     <div class="actions">
                         <a href="{{ url_for('tournament_view', t_id=t.id) }}" class="styled-button secondary-button">Open</a>
+                        {% if session.admin_logged_in %}
                         <form action="{{ url_for('delete_tournament', t_id=t.id) }}" method="post" style="display:inline">
                             <button type="submit" class="styled-button danger-button">Delete</button>
                         </form>
+                        {% endif %}
                     </div>
                 </li>
                 {% endfor %}

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -60,12 +60,16 @@
                 <tr>
                     <td>{{ m.p1 }} vs {{ m.p2 }}</td>
                     <td>
+                        {% if session.admin_logged_in %}
                         <form action="{{ url_for('record_score', t_id=t_id, group='A', index=ns.idx) }}" method="post" style="display:inline">
                             <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
                             -
                             <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
                             <button type="submit" class="styled-button primary-button">Save</button>
                         </form>
+                        {% else %}
+                            {{ m.score1 if m.score1 is not none else '' }} - {{ m.score2 if m.score2 is not none else '' }}
+                        {% endif %}
                     </td>
                 </tr>
                 {% set ns.idx = ns.idx + 1 %}


### PR DESCRIPTION
## Summary
- allow administrator login/logout on the main page
- restrict tournament management actions to logged in admin
- hide restricted buttons from guests
- document default admin credentials

## Testing
- `python -m py_compile app.py tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_6880c4a6d8308324a40e46d438ebf14c