### PR TITLE
Improve login persistence and style

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, request, redirect, url_for, session
 from tournament import draw_group, schedule_round_robin
 import json
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
 
 ADMIN_USERNAME = "admin"
 ADMIN_PASSWORD = "password"
@@ -35,6 +35,7 @@ init_db()
 
 app = Flask(__name__, static_folder='static', template_folder='templates')
 app.secret_key = 'replace-this-secret'
+app.permanent_session_lifetime = timedelta(days=365)
 
 
 @app.route('/login', methods=['POST'])
@@ -42,6 +43,7 @@ def login():
     username = request.form.get('username', '')
     password = request.form.get('password', '')
     if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
+        session.permanent = True
         session['admin_logged_in'] = True
     return redirect(url_for('index'))
 

--- a/static/style.css
+++ b/static/style.css
@@ -52,6 +52,11 @@ body {
   margin: -0.5em -1em;
 }
 
+.login-form {
+  display: flex;
+  gap: 0.5em;
+}
+
 h1, h2, h3 {
   font-family: 'Roboto Condensed', 'Helvetica Neue', Arial, sans-serif;
   margin-top: 0;
@@ -174,6 +179,8 @@ a:hover {
   border: 1px solid var(--son-grey);
   border-radius: var(--son-radius);
   transition: box-shadow 150ms ease-out;
+  background: var(--son-white);
+  color: var(--son-black);
 }
 
 .styled-input:focus {

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,20 +12,19 @@
 <body>
     <header class="site-header">
         <h1>SON Darts Championship</h1>
+        {% if not session.admin_logged_in %}
+        <form action="{{ url_for('login') }}" method="post" class="login-form">
+            <input type="text" name="username" placeholder="Username" class="styled-input" required>
+            <input type="password" name="password" placeholder="Password" class="styled-input" required>
+            <button type="submit" class="styled-button secondary-button">Login</button>
+        </form>
+        {% else %}
+        <form action="{{ url_for('logout') }}" method="post" class="login-form">
+            <button type="submit" class="styled-button secondary-button">Logout</button>
+        </form>
+        {% endif %}
         <img src="{{ url_for('static', filename='Dutch_darts_v2.png') }}" alt="Logo">
     </header>
-
-    {% if not session.admin_logged_in %}
-    <form action="{{ url_for('login') }}" method="post" class="card" style="margin-bottom:1em;">
-        <input type="text" name="username" placeholder="Username" class="styled-input" required>
-        <input type="password" name="password" placeholder="Password" class="styled-input" required style="margin-top:0.5em;">
-        <button type="submit" class="styled-button secondary-button" style="margin-top:0.5em;">Login</button>
-    </form>
-    {% else %}
-    <form action="{{ url_for('logout') }}" method="post" class="card" style="margin-bottom:1em;">
-        <button type="submit" class="styled-button secondary-button">Logout</button>
-    </form>
-    {% endif %}
 
     <div class="index-layout">
         <section id="new-tournament" class="card">


### PR DESCRIPTION
## Summary
- keep admin logged in across sessions
- display login/logout buttons in the site header
- style login form inputs with white background

## Testing
- `python -m py_compile app.py tournament.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c6fd81ac832490e60723bd7407ae