### PR TITLE
Allow admins to record knockout scores

### DIFF
--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -20,24 +20,62 @@
         <section class="card" style="width: 50%;">
             <h2>Quarterfinals</h2>
             <table>
-                <tr><th>Match</th></tr>
+                <tr><th>Match</th><th>Score</th></tr>
                 {% for m in bracket.qfs %}
-                <tr><td>{{ m.p1 }} vs {{ m.p2 }}</td></tr>
+                <tr>
+                    <td>{{ m.p1 }} vs {{ m.p2 }}</td>
+                    <td>
+                        {% if session.admin_logged_in %}
+                        <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='qf', index=loop.index0) }}" method="post">
+                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
+                            -
+                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
+                            <button type="submit" class="styled-button primary-button">Save</button>
+                        </form>
+                        {% else %}
+                            {{ m.score1 if m.score1 is not none else '' }} - {{ m.score2 if m.score2 is not none else '' }}
+                        {% endif %}
+                    </td>
+                </tr>
                 {% endfor %}
             </table>
         </section>
         <section class="card" style="width: 50%;">
             <h2>Semifinals</h2>
             <table>
-                <tr><th>Match</th></tr>
+                <tr><th>Match</th><th>Score</th></tr>
                 {% for m in bracket.sfs %}
-                <tr><td>{{ m.p1 }} vs {{ m.p2 }}</td></tr>
+                <tr>
+                    <td>{{ m.p1 }} vs {{ m.p2 }}</td>
+                    <td>
+                        {% if session.admin_logged_in and 'Winner' not in m.p1 and 'Winner' not in m.p2 %}
+                        <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='sf', index=loop.index0) }}" method="post">
+                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
+                            -
+                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
+                            <button type="submit" class="styled-button primary-button">Save</button>
+                        </form>
+                        {% else %}
+                            {{ m.score1 if m.score1 is not none else '' }} - {{ m.score2 if m.score2 is not none else '' }}
+                        {% endif %}
+                    </td>
+                </tr>
                 {% endfor %}
             </table>
         </section>
         <section class="card" style="width: 50%;">
             <h2>Final</h2>
             <p>{{ bracket.final.p1 }} vs {{ bracket.final.p2 }}</p>
+            {% if session.admin_logged_in and 'Winner' not in bracket.final.p1 and 'Winner' not in bracket.final.p2 %}
+            <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='final', index=0) }}" method="post">
+                <input type="number" name="score1" min="0" required style="width:3em;" value="{{ bracket.final.score1 if bracket.final.score1 is not none }}">
+                -
+                <input type="number" name="score2" min="0" required style="width:3em;" value="{{ bracket.final.score2 if bracket.final.score2 is not none }}">
+                <button type="submit" class="styled-button primary-button">Save</button>
+            </form>
+            {% else %}
+            <p>{{ bracket.final.score1 if bracket.final.score1 is not none else '' }} - {{ bracket.final.score2 if bracket.final.score2 is not none else '' }}</p>
+            {% endif %}
         </section>
         {% else %}
         <section class="card">


### PR DESCRIPTION
## Summary
- allow knockout bracket to store scores
- persist bracket state at first view
- update knockout stage page to show score forms for admins
- redirect guests from edit routes
- restrict editing of semifinals and final until players are known

## Testing
- `python -m py_compile app.py tournament.py`


------
https://chatgpt.com/codex/tasks/task_e_68814f2e04fc83248ea67295eb8581c5