### PR TITLE
Restrict score entry until knockout players known

### DIFF
--- a/app.py
+++ b/app.py
@@ -273,6 +273,15 @@ def _update_knockout_progress(bracket):
         bracket['final']['p2'] = winners_sf[1]
 
 
+def _players_known(match):
+    """Return True if both players have been decided."""
+    p1 = match.get('p1')
+    p2 = match.get('p2')
+    if not p1 or not p2:
+        return False
+    return not str(p1).startswith('Winner') and not str(p2).startswith('Winner')
+
+
 @app.route('/tournament/<int:t_id>/record/<group>/<int:index>', methods=['POST'])
 def record_score(t_id: int, group: str, index: int):
     if not session.get('admin_logged_in'):
@@ -343,6 +352,10 @@ def record_knockout_score(t_id: int, stage: str, index: int):
             return redirect(url_for('knockout_view', t_id=t_id))
         match = matches[index]
     else:
+        conn.close()
+        return redirect(url_for('knockout_view', t_id=t_id))
+
+    if stage in ('sfs', 'final') and not _players_known(match):
         conn.close()
         return redirect(url_for('knockout_view', t_id=t_id))
 

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -48,7 +48,7 @@
                 <tr>
                     <td>{{ m.p1 }} vs {{ m.p2 }}</td>
                     <td>
-                        {% if session.admin_logged_in and m.p1 and m.p2 %}
+                        {% if session.admin_logged_in and m.p1 and m.p2 and 'Winner of' not in m.p1 and 'Winner of' not in m.p2 %}
                         <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='sfs', index=loop.index0) }}" method="post">
                             <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
                             -
@@ -70,7 +70,7 @@
                 <tr>
                     <td>{{ bracket.final.p1 }} vs {{ bracket.final.p2 }}</td>
                     <td>
-                        {% if session.admin_logged_in and bracket.final.p1 and bracket.final.p2 %}
+                        {% if session.admin_logged_in and bracket.final.p1 and bracket.final.p2 and 'Winner of' not in bracket.final.p1 and 'Winner of' not in bracket.final.p2 %}
                         <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='final', index=0) }}" method="post">
                             <input type="number" name="score1" min="0" required style="width:3em;" value="{{ bracket.final.score1 if bracket.final.score1 is not none }}">
                             -


### PR DESCRIPTION
## Summary
- prevent editing semifinal or final scores before participants are decided
- hide knockout entry forms until players are known

## Testing
- `python -m py_compile app.py tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_6881530bc3dc8324a62719103b578340