### PR TITLE
Clean up templates and styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,11 @@ def inject_tournament_name():
     return dict(current_tournament_name=name)
 
 
+@app.context_processor
+def inject_current_year():
+    return {'current_year': datetime.utcnow().year}
+
+
 @app.route('/login', methods=['POST'])
 def login():
     username = request.form.get('username', '')

--- a/static/style.css
+++ b/static/style.css
@@ -322,6 +322,10 @@ h3 {
   color: var(--text-tertiary);
 }
 
+.score-input {
+  width: 3em;
+}
+
 /* Enhanced Tables */
 table {
   width: 100%;
@@ -456,6 +460,7 @@ tr:last-child td {
 
 .add-player-form .styled-button {
   flex-shrink: 0;
+  margin-top: 0.25em;
 }
 
 /* Player Container */
@@ -505,6 +510,25 @@ tr:last-child td {
 /* Add spacing for better content flow */
 .card h2 {
   margin-bottom: 2rem;
+}
+
+.standings-title {
+  line-height: 0.6;
+}
+
+.go-link {
+  margin-top: 1em;
+  display: inline-block;
+}
+
+.back-link {
+  margin-bottom: 1em;
+  display: inline-block;
+  width: 200px;
+}
+
+.champion-line {
+  margin-top: 0.5em;
 }
 
 .card p {
@@ -645,10 +669,6 @@ tr:last-child td {
     justify-content: center;
   }
   
-  .footer-nav {
-    flex-wrap: wrap;
-    gap: 1rem;
-  }
 }
 
 @media (max-width: 480px) {
@@ -749,6 +769,10 @@ tr:last-child td {
   justify-content: center;
   align-items: center;
   height: 100vh;
+}
+
+.loading-container img {
+  max-width: 10%;
 }
 
 /*knockout card design*/

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Darts Tournament Manager</title>
-    <style>
-    @import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,100..900;1,100..900&display=swap');
-    </style>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 
@@ -29,27 +26,27 @@
     {% endif %}
 </header>
 
-<body style="height: 100%; flex: 1">
+<body>
     <div class="index-layout">
-        <section id="new-tournament" class="card" style="width: 80%;">
+        <section id="new-tournament" class="card">
             <h2>New Tournament</h2>
             {% if session.admin_logged_in %}
             <form action="{{ url_for('set_title') }}" method="post" class="add-player-form">
-                <input type="text" class="styled-input" name="tournament_title" placeholder="Tournament title" value="{{ session.tournament_title }}" style="width: 80%">
-                <button type="submit" class="styled-button primary-button" style="margin-top: 0.25em;">Set Title</button>
+                <input type="text" class="styled-input" name="tournament_title" placeholder="Tournament title" value="{{ session.tournament_title }}">
+                <button type="submit" class="styled-button primary-button">Set Title</button>
             </form>
             <form action="{{ url_for('add_player') }}" method="post" class="add-player-form">
-                <input type="text" class="styled-input" name="player_name" placeholder="Player name" style="width: 80%">
-                <button type="submit" class="styled-button primary-button" style="margin-top: 0.25em;">Add</button>
+                <input type="text" class="styled-input" name="player_name" placeholder="Player name">
+                <button type="submit" class="styled-button primary-button">Add</button>
             </form>
 
             <div class="player-container">
                 {% if players %}
-                <ul id="player-list" style="border: 1px solid #000; padding: 10px; list-style-type: none; border-radius: 8px;">
+                <ul id="player-list">
                     {% for p in players %}
-                    <li style="border-bottom: 1px solid #ccc; padding: 5px 0;">
+                    <li>
                         {{ p }}
-                        <form action="{{ url_for('remove_player', index=loop.index0) }}" method="post" style="display:inline; float: right;">
+                        <form action="{{ url_for('remove_player', index=loop.index0) }}" method="post">
                             <button type="submit" class="styled-button danger-button">Remove</button>
                         </form>
                     </li>
@@ -67,18 +64,18 @@
             {% endif %}
         </section>
 
-        <section id="past-tournaments" class="card" style="width: 85%;">
-            <h2 style:"text-align: left;">Past Tournaments</h2>
+        <section id="past-tournaments" class="card">
+            <h2>Past Tournaments</h2>
             {% if tournaments %}
             <ul class="tournament-list">
                 {% for t in tournaments %}
-                <li style="border-bottom: 1px solid #ccc;">
+                <li>
                     <strong>{{ t.name }}</strong> - {{ t.created_at }}<br>
                     <span class="caption">Players in tournament: {{ t.players|length }}</span>
                     <div class="actions">
-                        <a href="{{ url_for('tournament_view', t_id=t.id) }}" class="styled-button secondary-button" style="margin-top: 0px">Open</a>
+                        <a href="{{ url_for('tournament_view', t_id=t.id) }}" class="styled-button secondary-button">Open</a>
                         {% if session.admin_logged_in %}
-                        <form action="{{ url_for('delete_tournament', t_id=t.id) }}" method="post" style="display:inline">
+                        <form action="{{ url_for('delete_tournament', t_id=t.id) }}" method="post">
                             <button type="submit" class="styled-button danger-button">Delete</button>
                         </form>
                         {% endif %}
@@ -92,17 +89,6 @@
         </section>
     </div>
 
-    <section id="group-stage" style="display:none">
-        <h2>Group Stage</h2>
-        <div id="groups"></div>
-        <div id="group-matches"></div>
-        <button id="start-knockout" disabled>Start Knockout Phase</button>
-    </section>
-
-    <section id="knockout-stage" style="display:none">
-        <h2>Knockout Stage</h2>
-        <div id="knockout-bracket"></div>
-    </section>
 </body>
 
 <footer class="site-footer">

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Knockout Stage</title>
-    <style>
-    @import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,100..900;1,100..900&display=swap');
-    </style>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
@@ -14,7 +11,7 @@
         <h1>{{ current_tournament_name }}</h1>
         <img src="{{ url_for('static', filename='Dutch_darts_v2.png') }}" alt="Logo">
     </header>
-    <a href="{{ url_for('tournament_view', t_id=t_id) }}" class="styled-button secondary-button" style="margin-bottom:1em;display:inline-block; width: 200px;" >Back to Group Stage</a>
+    <a href="{{ url_for('tournament_view', t_id=t_id) }}" class="styled-button secondary-button back-link">Back to Group Stage</a>
     <div class="knockout-container">
         {% if bracket %}
         <section class="knockout-card">
@@ -27,9 +24,9 @@
                     <td>
                         {% if session.admin_logged_in %}
                         <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='qfs', index=loop.index0) }}" method="post">
-                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
+                            <input type="number" name="score1" min="0" required class="score-input" value="{{ m.score1 if m.score1 is not none }}">
                             -
-                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
+                            <input type="number" name="score2" min="0" required class="score-input" value="{{ m.score2 if m.score2 is not none }}">
                             <button type="submit" class="styled-button primary-button">Save</button>
                         </form>
                         {% else %}
@@ -50,9 +47,9 @@
                     <td>
                         {% if session.admin_logged_in and m.p1 and m.p2 and 'Winner of' not in m.p1 and 'Winner of' not in m.p2 %}
                         <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='sfs', index=loop.index0) }}" method="post">
-                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
+                            <input type="number" name="score1" min="0" required class="score-input" value="{{ m.score1 if m.score1 is not none }}">
                             -
-                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
+                            <input type="number" name="score2" min="0" required class="score-input" value="{{ m.score2 if m.score2 is not none }}">
                             <button type="submit" class="styled-button primary-button">Save</button>
                         </form>
                         {% else %}
@@ -72,9 +69,9 @@
                     <td>
                         {% if session.admin_logged_in and bracket.final.p1 and bracket.final.p2 and 'Winner of' not in bracket.final.p1 and 'Winner of' not in bracket.final.p2 %}
                         <form action="{{ url_for('record_knockout_score', t_id=t_id, stage='final', index=0) }}" method="post">
-                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ bracket.final.score1 if bracket.final.score1 is not none }}">
+                            <input type="number" name="score1" min="0" required class="score-input" value="{{ bracket.final.score1 if bracket.final.score1 is not none }}">
                             -
-                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ bracket.final.score2 if bracket.final.score2 is not none }}">
+                            <input type="number" name="score2" min="0" required class="score-input" value="{{ bracket.final.score2 if bracket.final.score2 is not none }}">
                             <button type="submit" class="styled-button primary-button">Save</button>
                         </form>
                         {% else %}
@@ -84,7 +81,7 @@
                 </tr>
             </table>
             {% if bracket.final.score1 is not none and bracket.final.score2 is not none %}
-            <p style="margin-top:0.5em;"><strong>Champion: {{ bracket.final.p1 if bracket.final.score1 >= bracket.final.score2 else bracket.final.p2 }}</strong></p>
+            <p class="champion-line"><strong>Champion: {{ bracket.final.p1 if bracket.final.score1 >= bracket.final.score2 else bracket.final.p2 }}</strong></p>
             {% endif %}
         </section>
         {% else %}

--- a/templates/loading.html
+++ b/templates/loading.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <div class="loading-container">
-        <img style="max-width: 10%;" src="{{ url_for('static', filename='loading.gif') }}" alt="Loading">
+        <img src="{{ url_for('static', filename='loading.gif') }}" alt="Loading">
     </div>
 </body>
 </html>

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tournament</title>
-    <style>
-    @import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,100..900;1,100..900&display=swap');
-    </style>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
@@ -15,14 +12,14 @@
         <img src="{{ url_for('static', filename='Dutch_darts_v2.png') }}" alt="Logo">
     </header>
     <form id="reset-form" action="{{ url_for('reset') }}" method="post">
-        <button id="reset-btn" type="button" class="styled-button secondary-button" style="margin-left: 24px">Go back to start</button>
+        <button id="reset-btn" type="button" class="styled-button secondary-button">Go back to start</button>
     </form>
 
-    <div id="confirm-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5);">
-        <div style="background:#fff; padding:1em; border-radius:5px; width:200px; margin:20% auto; text-align:center; color:#000;">
+    <div id="confirm-modal" style="display:none;">
+        <div>
             <p>Are you sure?</p>
-            <button id="confirm-yes" class="styled-button danger-button" style="margin: 2px">Yes</button>
-            <button id="confirm-no" class="styled-button secondary-button" style="margin: 2px">No</button>
+            <button id="confirm-yes" class="styled-button danger-button">Yes</button>
+            <button id="confirm-no" class="styled-button secondary-button">No</button>
         </div>
     </div>
 
@@ -39,11 +36,11 @@
             </section>
 
             <section class="standings card">
-                <h2 style="line-height: 0.6">Standings</h2>
+                <h2 class="standings-title">Standings</h2>
                 <table>
                     <tr><th>Player</th><th>Points</th><th>GD</th></tr>
                     {% for s in standings_a %}
-                    <tr><td style="padding: 1em;">{{ s.name }}</td><td style="padding: 1em;">{{ s.points }}</td><td style="padding: 1em;">{{ s.gd }}</td></tr>
+                    <tr><td>{{ s.name }}</td><td>{{ s.points }}</td><td>{{ s.gd }}</td></tr>
                     {% endfor %}
                 </table>
             </section>
@@ -53,7 +50,7 @@
             <h2>Group Stage</h2>
             {% set ns = namespace(idx=0) %}
             {% for round in schedule_rounds %}
-            <h3 style="text-align: left;">Round {{ loop.index }}</h3>
+            <h3>Round {{ loop.index }}</h3>
             <table>
                 <tr><th>Match</th><th>Score</th></tr>
                 {% for m in round %}
@@ -62,9 +59,9 @@
                     <td>
                         {% if session.admin_logged_in %}
                         <form action="{{ url_for('record_score', t_id=t_id, group='A', index=ns.idx) }}" method="post">
-                            <input type="number" name="score1" min="0" required style="width:3em;" value="{{ m.score1 if m.score1 is not none }}">
+                            <input type="number" name="score1" min="0" required class="score-input" value="{{ m.score1 if m.score1 is not none }}">
                             -
-                            <input type="number" name="score2" min="0" required style="width:3em;" value="{{ m.score2 if m.score2 is not none }}">
+                            <input type="number" name="score2" min="0" required class="score-input" value="{{ m.score2 if m.score2 is not none }}">
                             <button type="submit" class="styled-button primary-button">Save</button>
                         </form>
                         {% else %}
@@ -79,7 +76,7 @@
         </div>
     </div>
 
-    <a href="{{ url_for('knockout_view', t_id=t_id) }}" class="styled-button primary-button" style="margin-top:1em; display:inline-block;">Go to Knockout</a>
+    <a href="{{ url_for('knockout_view', t_id=t_id) }}" class="styled-button primary-button go-link">Go to Knockout</a>
 
     <script>
         const resetBtn = document.getElementById('reset-btn');


### PR DESCRIPTION
## Summary
- remove inline styles and unused font imports
- trim unused CSS rules and add classes for scores and links
- include current year in templates

## Testing
- `python -m py_compile app.py tournament.py`
- `flake8` *(fails: line length issues)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881574351fc832486ed3b01f6dcedcf