### PR TITLE
Add front-end player list and create tournament in one step

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,7 +77,7 @@ def logout():
 
 @app.route('/')
 def index():
-    players = session.get('players', [])
+    players = []
     page = request.args.get('page', 1, type=int)
     per_page = 3
     conn = get_db()
@@ -149,7 +149,11 @@ def set_title():
 def start_tournament():
     if not session.get('admin_logged_in'):
         return redirect(url_for('index'))
-    players = session.get('players', [])
+    players_json = request.form.get('players_json', '[]')
+    try:
+        players = json.loads(players_json)
+    except json.JSONDecodeError:
+        players = []
     if not players:
         return redirect(url_for('index'))
     group_a = draw_group(players.copy())
@@ -170,7 +174,7 @@ def start_tournament():
     }
 
     conn = get_db()
-    name = session.pop('tournament_title', '').strip()
+    name = request.form.get('title', '').strip()
     if not name:
         name = f"Tournament {datetime.utcnow().isoformat(timespec='seconds')}"
     cur = conn.execute(
@@ -182,7 +186,6 @@ def start_tournament():
     conn.close()
 
     session['current_tournament_id'] = tid
-    session.pop('players', None)
     return render_template('loading.html', t_id=tid)
 
 

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,49 @@
+// Front-end logic for adding players and creating tournament without page reload
+
+document.addEventListener('DOMContentLoaded', () => {
+  const players = [];
+  const addForm = document.getElementById('add-player-form');
+  const playerInput = document.getElementById('player-name');
+  const playerList = document.getElementById('player-list');
+  const playersField = document.getElementById('players-json');
+  const noPlayers = document.getElementById('no-players');
+  const createForm = document.getElementById('create-form');
+  const titleInput = document.getElementById('tournament-title');
+  const createTitle = document.getElementById('create-title');
+
+  function renderPlayers() {
+    playerList.innerHTML = '';
+    players.forEach((p, idx) => {
+      const li = document.createElement('li');
+      li.textContent = p;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = 'Remove';
+      btn.className = 'styled-button danger-button';
+      btn.addEventListener('click', () => {
+        players.splice(idx, 1);
+        renderPlayers();
+      });
+      li.appendChild(btn);
+      playerList.appendChild(li);
+    });
+    playersField.value = JSON.stringify(players);
+    noPlayers.style.display = players.length ? 'none' : 'block';
+  }
+
+  addForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const name = playerInput.value.trim();
+    if (name) {
+      players.push(name);
+      playerInput.value = '';
+      renderPlayers();
+    }
+  });
+
+  createForm.addEventListener('submit', () => {
+    createTitle.value = titleInput.value.trim();
+  });
+
+  renderPlayers();
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,33 +31,20 @@
         <section id="new-tournament" class="card">
             <h2>New Tournament</h2>
             {% if session.admin_logged_in %}
-            <form action="{{ url_for('set_title') }}" method="post" class="add-player-form">
-                <input type="text" class="styled-input" name="tournament_title" placeholder="Tournament title" value="{{ session.tournament_title }}">
-                <button type="submit" class="styled-button primary-button">Set Title</button>
-            </form>
-            <form action="{{ url_for('add_player') }}" method="post" class="add-player-form">
-                <input type="text" class="styled-input" name="player_name" placeholder="Player name">
+            <input type="text" id="tournament-title" class="styled-input" placeholder="Tournament title">
+            <form id="add-player-form" class="add-player-form">
+                <input type="text" id="player-name" class="styled-input" placeholder="Player name">
                 <button type="submit" class="styled-button primary-button">Add</button>
             </form>
 
             <div class="player-container">
-                {% if players %}
-                <ul id="player-list">
-                    {% for p in players %}
-                    <li>
-                        {{ p }}
-                        <form action="{{ url_for('remove_player', index=loop.index0) }}" method="post">
-                            <button type="submit" class="styled-button danger-button">Remove</button>
-                        </form>
-                    </li>
-                    {% endfor %}
-                </ul>
-                <form action="{{ url_for('start_tournament') }}" method="post">
-                    <button type="submit" class="styled-button primary-button">Start Tournament</button>
+                <p id="no-players">No players added yet.</p>
+                <ul id="player-list"></ul>
+                <form id="create-form" action="{{ url_for('start_tournament') }}" method="post">
+                    <input type="hidden" name="title" id="create-title">
+                    <input type="hidden" name="players_json" id="players-json">
+                    <button type="submit" class="styled-button primary-button">Create Tournament</button>
                 </form>
-                {% else %}
-                <p>No players added yet.</p>
-                {% endif %}
             </div>
             {% else %}
             <p>Login as admin to create tournaments.</p>
@@ -96,7 +83,7 @@
             {% endif %}
         </section>
     </div>
-
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 
 <footer class="site-footer">


### PR DESCRIPTION
## Summary
- handle players entirely on the client before creation
- parse submitted players and title when starting a tournament
- update index page for dynamic player list and single create button
- add small JS helper script

## Testing
- `python -m py_compile app.py tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_68822f80440c8324943af652be7f22e8